### PR TITLE
hotfix: GitHub release page no longer supports `after` parameter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           name: coverage-${{ matrix.python_version }}
           path: .coverage.${{ matrix.python_version }}
+          include-hidden-files: true
 
   coverage:
     name: Coverage

--- a/tests/test_cache_requests.py
+++ b/tests/test_cache_requests.py
@@ -12,7 +12,7 @@ import claranet_tfwrapper as tfwrapper
 
 
 @pytest.fixture
-def terraform_releases_html_after_v0_13_0():
+def terraform_releases_html_q_0_12():
     return """
 <!DOCTYPE html>
 <html lang="en">
@@ -74,19 +74,19 @@ class AutoclosingBytesIO(io.BytesIO):
 
 def test_search_on_github_cache_terraform_releases_200(
     tmp_working_dir,
-    terraform_releases_html_after_v0_13_0,
+    terraform_releases_html_q_0_12,
 ):
     with mock.patch("io.BytesIO", AutoclosingBytesIO):
         with pook.use():
             repo = "hashicorp/terraform"
-            releases_url = "https://github.com/{}/releases?after=v0.13.0".format(repo)
+            releases_url = "https://github.com/{}/releases?q=0.12".format(repo)
 
             # A volatile mock that can only be invoked once
             pook.get(
                 releases_url,
                 reply=200,
                 response_type="text/plain",
-                response_body=terraform_releases_html_after_v0_13_0,
+                response_body=terraform_releases_html_q_0_12,
                 response_headers={
                     "Status": "200 OK",
                     "ETag": 'W/"df0474ebd25f223a95926ba58e11e77b"',
@@ -110,13 +110,11 @@ def test_search_on_github_cache_terraform_releases_200(
     assert not pook.isactive()
 
 
-def test_search_on_github_cache_terraform_releases_does_not_cache_error_429(
-    tmp_working_dir, terraform_releases_html_after_v0_13_0
-):
+def test_search_on_github_cache_terraform_releases_does_not_cache_error_429(tmp_working_dir, terraform_releases_html_q_0_12):
     with mock.patch("io.BytesIO", AutoclosingBytesIO):
         with pook.use():
             repo = "hashicorp/terraform"
-            releases_url = "https://github.com/{}/releases?after=v0.13.0".format(repo)
+            releases_url = "https://github.com/{}/releases?q=0.12".format(repo)
 
             # volatile mocks that can only be invoked once each
             pook.get(
@@ -129,7 +127,7 @@ def test_search_on_github_cache_terraform_releases_does_not_cache_error_429(
                 releases_url,
                 reply=200,
                 response_type="text/plain",
-                response_body=terraform_releases_html_after_v0_13_0,
+                response_body=terraform_releases_html_q_0_12,
                 response_headers={
                     "Status": "200 OK",
                     "ETag": 'W/"df0474ebd25f223a95926ba58e11e77b"',
@@ -159,12 +157,12 @@ def test_search_on_github_cache_terraform_releases_does_not_cache_error_429(
 
 def test_search_on_github_cache_terraform_releases_does_not_cache_error_403(
     tmp_working_dir,
-    terraform_releases_html_after_v0_13_0,
+    terraform_releases_html_q_0_12,
 ):
     with mock.patch("io.BytesIO", AutoclosingBytesIO):
         with pook.use():
             repo = "hashicorp/terraform"
-            releases_url = "https://github.com/{}/releases?after=v0.13.0".format(repo)
+            releases_url = "https://github.com/{}/releases?q=0.12".format(repo)
 
             # volatile mocks that can only be invoked once each
             pook.get(
@@ -177,7 +175,7 @@ def test_search_on_github_cache_terraform_releases_does_not_cache_error_403(
                 releases_url,
                 reply=200,
                 response_type="text/plain",
-                response_body=terraform_releases_html_after_v0_13_0,
+                response_body=terraform_releases_html_q_0_12,
                 response_headers={
                     "Status": "200 OK",
                     "ETag": 'W/"df0474ebd25f223a95926ba58e11e77b"',
@@ -207,12 +205,12 @@ def test_search_on_github_cache_terraform_releases_does_not_cache_error_403(
 
 def test_search_on_github_cache_terraform_releases_does_not_cache_error_404(
     tmp_working_dir,
-    terraform_releases_html_after_v0_13_0,
+    terraform_releases_html_q_0_12,
 ):
     with mock.patch("io.BytesIO", AutoclosingBytesIO):
         with pook.use():
             repo = "hashicorp/terraform"
-            releases_url = "https://github.com/{}/releases?after=v0.13.0".format(repo)
+            releases_url = "https://github.com/{}/releases?q=0.12".format(repo)
 
             # volatile mocks that can only be invoked once each
             pook.get(
@@ -225,7 +223,7 @@ def test_search_on_github_cache_terraform_releases_does_not_cache_error_404(
                 releases_url,
                 reply=200,
                 response_type="text/plain",
-                response_body=terraform_releases_html_after_v0_13_0,
+                response_body=terraform_releases_html_q_0_12,
                 response_headers={
                     "Status": "200 OK",
                     "ETag": 'W/"df0474ebd25f223a95926ba58e11e77b"',

--- a/tests/test_search_on_github.py
+++ b/tests/test_search_on_github.py
@@ -7,7 +7,7 @@ import claranet_tfwrapper as tfwrapper
 
 
 @pytest.fixture
-def provider_releases_html_after_v2_6_0():
+def provider_releases_html_q_2_5():
     return """
 <!DOCTYPE html>
 <html lang="en">
@@ -34,7 +34,7 @@ def provider_releases_html_after_v2_6_0():
 
 
 @pytest.fixture
-def provider_releases_html_after_v1_3_0():
+def provider_releases_html_q_1_2():
     return """
 <!DOCTYPE html>
 <html lang="en">
@@ -62,28 +62,28 @@ def provider_releases_html_after_v1_3_0():
 
 def test_search_on_github_provider_releases(
     requests_mock,
-    provider_releases_html_after_v2_6_0,
-    provider_releases_html_after_v1_3_0,
+    provider_releases_html_q_2_5,
+    provider_releases_html_q_1_2,
 ):
     from claranet_tfwrapper import GITHUB_RELEASES
 
     repo = "claranet/terraform-provider-gitlab"
     releases_url = GITHUB_RELEASES.format(repo)
-    releases_url_after_v2_6_0 = releases_url + "?after=v2.6.0"
-    releases_url_after_v1_3_0 = releases_url + "?after=v1.3.0"
+    releases_url_q_2_5 = releases_url + "?q=2.5"
+    releases_url_q_1_2 = releases_url + "?q=1.2"
 
     requests_mock.get(
-        releases_url_after_v2_6_0,
+        releases_url_q_2_5,
         complete_qs=True,
-        text=provider_releases_html_after_v2_6_0,
+        text=provider_releases_html_q_2_5,
     )
     requests_mock.get(
-        releases_url_after_v1_3_0,
+        releases_url_q_1_2,
         complete_qs=True,
-        text=provider_releases_html_after_v1_3_0,
+        text=provider_releases_html_q_1_2,
     )
 
-    assert provider_releases_html_after_v2_6_0 == requests.get(releases_url_after_v2_6_0).text
+    assert provider_releases_html_q_2_5 == requests.get(releases_url_q_2_5).text
 
     patch_regex = r"[0-9]+(((-alpha|-beta|-rc)[0-9]+)|(?P<dev>-dev))?"
     patch = tfwrapper.search_on_github(repo, "2.5", patch_regex, "")


### PR DESCRIPTION
This PR resolves an issue following recent changes on the GitHub releases web page that prevents discovering older versions of opentofu and terraform:

```
# tfwrapper init
Traceback (most recent call last):
  File "/home/patrick/.local/bin/tfwrapper", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/patrick/.local/pipx/venvs/claranet-tfwrapper/lib/python3.12/site-packages/claranet_tfwrapper/__init__.py", line 1389, in main
    download_tool_from_github(
  File "/home/patrick/.local/pipx/venvs/claranet-tfwrapper/lib/python3.12/site-packages/claranet_tfwrapper/__init__.py", line 721, in download_tool_from_github
    error(f"The version '{tool_version}' does not exist for tool {tool_type} in '{repo}' GitHub repository")
  File "/home/patrick/.local/pipx/venvs/claranet-tfwrapper/lib/python3.12/site-packages/claranet_tfwrapper/__init__.py", line 160, in error
    raise ValueError("{}\n\nUse -h to show the help message".format(message))
ValueError: The version '1.6' does not exist for tool tofu in 'opentofu/opentofu' GitHub repository

Use -h to show the help message

```

Note: we should definitely stop scrapping the web UI...