### PR TITLE
fix: do not download tool for foreach command

### DIFF
--- a/src/claranet_tfwrapper/__init__.py
+++ b/src/claranet_tfwrapper/__init__.py
@@ -1388,23 +1388,24 @@ def main(argv=None):
     # parse all args
     args = parse_args(argv or sys.argv[1:])
 
-    # select tool version for the stack if selected, with a fallback on v1.0
-    tool_version = (tf_config := stack_config.get(TOOL_TERRAFORM, {})).get(
-        "version", tf_config.get("vars", {}).get("version", "1.0")
-    )
-    if (v := Version.parse(tool_version, optional_minor_and_patch=True)).major < 1 or (v.major == 1 and v.minor < 6):
-        legacy_tool = True
-    else:
-        legacy_tool = stack_config.get("terraform", {}).get("legacy", False)
-
-    if not legacy_tool:
-        download_tool_from_github(
-            "opentofu/opentofu",
-            tool_version,
-            TOOL_OPENTOFU,
+    if args.func != foreach:
+        # select tool version for the stack if selected, with a fallback on v1.0
+        tool_version = (tf_config := stack_config.get(TOOL_TERRAFORM, {})).get(
+            "version", tf_config.get("vars", {}).get("version", "1.0")
         )
-    else:
-        select_terraform_version(tool_version)
+        if (v := Version.parse(tool_version, optional_minor_and_patch=True)).major < 1 or (v.major == 1 and v.minor < 6):
+            legacy_tool = True
+        else:
+            legacy_tool = stack_config.get("terraform", {}).get("legacy", False)
+
+        if not legacy_tool:
+            download_tool_from_github(
+                "opentofu/opentofu",
+                tool_version,
+                TOOL_OPENTOFU,
+            )
+        else:
+            select_terraform_version(tool_version)
 
     # convert args to dict
     wrapper_config.update(vars(args))


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Skip tool download for `foreach` command

- Prevent unnecessary OpenTofu/Terraform version selection

- Optimize command execution performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Command parsing"] --> B{"Is foreach command?"}
  B -->|Yes| C["Skip tool download"]
  B -->|No| D["Download OpenTofu/Terraform"]
  D --> E["Execute command"]
  C --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Skip tool download for foreach command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/claranet_tfwrapper/__init__.py

<ul><li>Added conditional check to skip tool download for <code>foreach</code> command<br> <li> Wrapped tool version selection and download logic in <code>if args.func != </code><br><code>foreach</code> condition<br> <li> Maintained existing tool selection behavior for other commands</ul>


</details>


  </td>
  <td><a href="https://github.com/claranet/tfwrapper/pull/576/files#diff-40c35867d3b075145e78c8607d0826637e7142fd64428182fb8a3d707567f189">+17/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

